### PR TITLE
SIMAL : fix le test qui ne passe plus car le dossier demat social n'existe plus

### DIFF
--- a/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerIntegrationTest.java
+++ b/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerIntegrationTest.java
@@ -25,6 +25,7 @@ class ReclamationControllerIntegrationTest {
     @Autowired
     private ObjectMapper objectMapper;
     @Test
+    @Tag("localOnly")
     void lorsqueLonDeposeUneReclamationPourUnDossierExistant_alorsRetourne200EtLaReclamationEnBody() throws Exception {
         // Given
         int numeroDossier = 178291;


### PR DESCRIPTION
petit correctif pour dire a la CI de ne plus exécuté le test d'intégration en lien avec un dossier car le dossier a été supprimé.

Vu que nous ne pouvons pas créer de dossier depuis l'api afin d'en maitriser le cycle de vie, nous prenons la décisions de skip les tests sur la CI et de les conservé uniquement en vue d'exécution manuel lors des developpements.