### PR TITLE
Simal-70 webhook hack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
 			<plugin>
 				<groupId>com.diffplug.spotless</groupId>
 				<artifactId>spotless-maven-plugin</artifactId>
-				<version>2.38.0</version>
+				<version>2.43.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -202,17 +202,6 @@
 							<exclude>**/*.txt</exclude>
 							<exclude>**/*.xml</exclude>
 						</excludes>
-					</java>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>com.diffplug.spotless</groupId>
-				<artifactId>spotless-maven-plugin</artifactId>
-				<version>2.43.0</version>
-				<configuration>
-					<java>
-						<googleJavaFormat/>
 					</java>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,17 @@
 					</java>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>com.diffplug.spotless</groupId>
+				<artifactId>spotless-maven-plugin</artifactId>
+				<version>2.43.0</version>
+				<configuration>
+					<java>
+						<googleJavaFormat/>
+					</java>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/fr/gouv/social/sireclamations/config/RetrofitConfiguration.java
+++ b/src/main/java/fr/gouv/social/sireclamations/config/RetrofitConfiguration.java
@@ -27,7 +27,7 @@ public class RetrofitConfiguration {
 
   private OkHttpClient createClient(String token) {
     HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
-    loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY);
+    loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BASIC); //NB : Des données personnelles et de santé sont envoyées. Ces données ne doivent pas figurer dans les LOGS
 
     Interceptor authInterceptor =
         chain -> {
@@ -77,7 +77,7 @@ public class RetrofitConfiguration {
     OkHttpClient client =
         new OkHttpClient.Builder()
             .addInterceptor(
-                new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
+                new HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BASIC))
             .build();
 
     return new Retrofit.Builder()

--- a/src/main/java/fr/gouv/social/sireclamations/config/RetrofitConfiguration.java
+++ b/src/main/java/fr/gouv/social/sireclamations/config/RetrofitConfiguration.java
@@ -27,7 +27,10 @@ public class RetrofitConfiguration {
 
   private OkHttpClient createClient(String token) {
     HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor();
-    loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BASIC); //NB : Des données personnelles et de santé sont envoyées. Ces données ne doivent pas figurer dans les LOGS
+    loggingInterceptor.setLevel(
+        HttpLoggingInterceptor.Level
+            .BASIC); // NB : Des données personnelles et de santé sont envoyées. Ces données ne
+    // doivent pas figurer dans les LOGS
 
     Interceptor authInterceptor =
         chain -> {

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/DeposerReclamationRequest.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/DeposerReclamationRequest.java
@@ -2,7 +2,6 @@ package fr.gouv.social.sireclamations.user_side;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-
 import java.time.LocalDateTime;
 import java.util.stream.Stream;
 

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/DeposerReclamationRequest.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/DeposerReclamationRequest.java
@@ -18,7 +18,8 @@ public class DeposerReclamationRequest {
   private final Etat etat;
   private final LocalDateTime dateDepot;
 
-  public DeposerReclamationRequest(int numeroProcedure, int numeroDossier, Etat etat, LocalDateTime dateDepot) {
+  public DeposerReclamationRequest(
+      int numeroProcedure, int numeroDossier, Etat etat, LocalDateTime dateDepot) {
     this.numeroProcedure = numeroProcedure;
     this.numeroDossier = numeroDossier;
     this.etat = etat;
@@ -37,9 +38,13 @@ public class DeposerReclamationRequest {
     this.numeroDossier = numeroDossier;
   }
 
-  public Etat getEtat() { return etat; }
+  public Etat getEtat() {
+    return etat;
+  }
 
-  public LocalDateTime getDateDepot() { return dateDepot; }
+  public LocalDateTime getDateDepot() {
+    return dateDepot;
+  }
 
   public enum Etat {
     BROUILLON("brouillon"),
@@ -59,8 +64,7 @@ public class DeposerReclamationRequest {
     }
 
     public static boolean isValid(String input) {
-      return Stream.of(Etat.values())
-              .anyMatch(state -> state.value.equals(input));
+      return Stream.of(Etat.values()).anyMatch(state -> state.value.equals(input));
     }
   }
 }

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/DeposerReclamationRequest.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/DeposerReclamationRequest.java
@@ -3,10 +3,31 @@ package fr.gouv.social.sireclamations.user_side;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
 public class DeposerReclamationRequest {
+  @NotNull(message = "Le numéro de procédure est obligatoire.")
+  @Positive(message = "Le numéro de procédure doit être un entier positif.")
+  private final int numeroProcedure;
+
   @NotNull(message = "Le numéro de dossier est obligatoire.")
   @Positive(message = "Le numéro de dossier doit être un entier positif.")
   private int numeroDossier;
+
+  private final Etat etat;
+  private final LocalDateTime dateDepot;
+
+  public DeposerReclamationRequest(int numeroProcedure, int numeroDossier, Etat etat, LocalDateTime dateDepot) {
+    this.numeroProcedure = numeroProcedure;
+    this.numeroDossier = numeroDossier;
+    this.etat = etat;
+    this.dateDepot = dateDepot;
+  }
+
+  public int getNumeroProcedure() {
+    return numeroProcedure;
+  }
 
   public int getNumeroDossier() {
     return numeroDossier;
@@ -14,5 +35,32 @@ public class DeposerReclamationRequest {
 
   public void setNumeroDossier(int numeroDossier) {
     this.numeroDossier = numeroDossier;
+  }
+
+  public Etat getEtat() { return etat; }
+
+  public LocalDateTime getDateDepot() { return dateDepot; }
+
+  public enum Etat {
+    BROUILLON("brouillon"),
+    EN_CONSTRUCTION("en_construction"),
+    EN_INSTRUCTION("en_instruction"),
+    ACCEPTE("accepte"),
+    REFUSE("refuse");
+
+    private final String value;
+
+    Etat(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public static boolean isValid(String input) {
+      return Stream.of(Etat.values())
+              .anyMatch(state -> state.value.equals(input));
+    }
   }
 }

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/DeposerReclamationRequest.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/DeposerReclamationRequest.java
@@ -45,6 +45,13 @@ public class DeposerReclamationRequest {
     return dateDepot;
   }
 
+  @Override
+  public String toString() {
+    return String.format(
+        "numeroProcedure=%s;numeroDossier=%s;etat=%s;dateDepot=%s",
+        numeroProcedure, numeroDossier, etat, dateDepot);
+  }
+
   public enum Etat {
     BROUILLON("brouillon"),
     EN_CONSTRUCTION("en_construction"),

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/GlobalControllerAdvice.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/GlobalControllerAdvice.java
@@ -4,19 +4,23 @@ import fr.gouv.social.sireclamations.hexagone.exceptions.AutoriteCompetenteNotFo
 import fr.gouv.social.sireclamations.hexagone.exceptions.CodePostalAbsentException;
 import fr.gouv.social.sireclamations.hexagone.exceptions.ContactNotFoundException;
 import fr.gouv.social.sireclamations.hexagone.exceptions.DematSocialException;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import java.util.Map;
+
 @ControllerAdvice
 public class GlobalControllerAdvice {
 
   private static final Logger logger = LoggerFactory.getLogger(GlobalControllerAdvice.class);
+  public static final String STATUS = "status";
+  public static final String MESSAGE = "message";
 
   @ExceptionHandler(AutoriteCompetenteNotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
@@ -24,7 +28,7 @@ public class GlobalControllerAdvice {
   public Map<String, String> handleAutoriteCompetenteNotFoundException(
       AutoriteCompetenteNotFoundException ex) {
     logger.error(ex.getMessage());
-    return Map.of("error", ex.getMessage());
+    return getGlobalControllerAdviceBodyResponse(HttpStatus.NOT_FOUND, ex.getMessage());
   }
 
   @ExceptionHandler(ContactNotFoundException.class)
@@ -32,7 +36,7 @@ public class GlobalControllerAdvice {
   @ResponseBody
   public Map<String, String> handleContactNotFoundException(ContactNotFoundException ex) {
     logger.error(ex.getMessage());
-    return Map.of("error", ex.getMessage());
+    return getGlobalControllerAdviceBodyResponse(HttpStatus.NOT_FOUND, ex.getMessage());
   }
 
   @ExceptionHandler(DematSocialException.class)
@@ -40,7 +44,7 @@ public class GlobalControllerAdvice {
   @ResponseBody
   public Map<String, String> handleDematSocialException(DematSocialException ex) {
     logger.error(ex.getMessage());
-    return Map.of("error", ex.getMessage());
+    return getGlobalControllerAdviceBodyResponse(HttpStatus.NOT_FOUND, ex.getMessage());
   }
 
   @ExceptionHandler(CodePostalAbsentException.class)
@@ -48,7 +52,7 @@ public class GlobalControllerAdvice {
   @ResponseBody
   public Map<String, String> handleCodePostalAbsentException(CodePostalAbsentException ex) {
     logger.error(ex.getMessage());
-    return Map.of("error", ex.getMessage());
+    return getGlobalControllerAdviceBodyResponse(HttpStatus.NOT_FOUND, ex.getMessage());
   }
 
   @ExceptionHandler(Exception.class)
@@ -56,6 +60,13 @@ public class GlobalControllerAdvice {
   @ResponseBody
   public Map<String, String> handleGenericException(Exception ex) {
     logger.error(ex.getMessage());
-    return Map.of("error", "Une erreur inattendue s'est produite." + ex.getMessage());
+    return getGlobalControllerAdviceBodyResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
+  }
+
+  public static Map<String,String> getGlobalControllerAdviceBodyResponse(HttpStatus httpStatus, String message) {
+    return Map.of(STATUS, String.valueOf(httpStatus.value()), MESSAGE, message);
+  }
+  public static ResponseEntity<Map<String, String>> getGlobalControllerAdviceResponse(HttpStatus httpStatus, String message) {
+    return ResponseEntity.status(httpStatus).body(getGlobalControllerAdviceBodyResponse(httpStatus, message));
   }
 }

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/GlobalControllerAdvice.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/GlobalControllerAdvice.java
@@ -24,7 +24,7 @@ public class GlobalControllerAdvice {
   @ExceptionHandler(AutoriteCompetenteNotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   @ResponseBody
-  public Map<String, String> handleAutoriteCompetenteNotFoundException(
+  public Map<String, Object> handleAutoriteCompetenteNotFoundException(
       AutoriteCompetenteNotFoundException ex) {
     logger.error(ex.getMessage());
     return getGlobalControllerAdviceBodyResponse(HttpStatus.NOT_FOUND, ex.getMessage());
@@ -33,7 +33,7 @@ public class GlobalControllerAdvice {
   @ExceptionHandler(ContactNotFoundException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   @ResponseBody
-  public Map<String, String> handleContactNotFoundException(ContactNotFoundException ex) {
+  public Map<String, Object> handleContactNotFoundException(ContactNotFoundException ex) {
     logger.error(ex.getMessage());
     return getGlobalControllerAdviceBodyResponse(HttpStatus.NOT_FOUND, ex.getMessage());
   }
@@ -41,7 +41,7 @@ public class GlobalControllerAdvice {
   @ExceptionHandler(DematSocialException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   @ResponseBody
-  public Map<String, String> handleDematSocialException(DematSocialException ex) {
+  public Map<String, Object> handleDematSocialException(DematSocialException ex) {
     logger.error(ex.getMessage());
     return getGlobalControllerAdviceBodyResponse(HttpStatus.NOT_FOUND, ex.getMessage());
   }
@@ -49,7 +49,7 @@ public class GlobalControllerAdvice {
   @ExceptionHandler(CodePostalAbsentException.class)
   @ResponseStatus(HttpStatus.NOT_FOUND)
   @ResponseBody
-  public Map<String, String> handleCodePostalAbsentException(CodePostalAbsentException ex) {
+  public Map<String, Object> handleCodePostalAbsentException(CodePostalAbsentException ex) {
     logger.error(ex.getMessage());
     return getGlobalControllerAdviceBodyResponse(HttpStatus.NOT_FOUND, ex.getMessage());
   }
@@ -57,17 +57,17 @@ public class GlobalControllerAdvice {
   @ExceptionHandler(Exception.class)
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   @ResponseBody
-  public Map<String, String> handleGenericException(Exception ex) {
+  public Map<String, Object> handleGenericException(Exception ex) {
     logger.error(ex.getMessage());
     return getGlobalControllerAdviceBodyResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
   }
 
-  public static Map<String, String> getGlobalControllerAdviceBodyResponse(
+  public static Map<String, Object> getGlobalControllerAdviceBodyResponse(
       HttpStatus httpStatus, String message) {
     return Map.of(STATUS, String.valueOf(httpStatus.value()), MESSAGE, message);
   }
 
-  public static ResponseEntity<Map<String, String>> getGlobalControllerAdviceResponse(
+  public static ResponseEntity<Map<String, Object>> getGlobalControllerAdviceResponse(
       HttpStatus httpStatus, String message) {
     return ResponseEntity.status(httpStatus)
         .body(getGlobalControllerAdviceBodyResponse(httpStatus, message));

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/GlobalControllerAdvice.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/GlobalControllerAdvice.java
@@ -4,6 +4,7 @@ import fr.gouv.social.sireclamations.hexagone.exceptions.AutoriteCompetenteNotFo
 import fr.gouv.social.sireclamations.hexagone.exceptions.CodePostalAbsentException;
 import fr.gouv.social.sireclamations.hexagone.exceptions.ContactNotFoundException;
 import fr.gouv.social.sireclamations.hexagone.exceptions.DematSocialException;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -12,8 +13,6 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
-
-import java.util.Map;
 
 @ControllerAdvice
 public class GlobalControllerAdvice {

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/GlobalControllerAdvice.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/GlobalControllerAdvice.java
@@ -63,10 +63,14 @@ public class GlobalControllerAdvice {
     return getGlobalControllerAdviceBodyResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
   }
 
-  public static Map<String,String> getGlobalControllerAdviceBodyResponse(HttpStatus httpStatus, String message) {
+  public static Map<String, String> getGlobalControllerAdviceBodyResponse(
+      HttpStatus httpStatus, String message) {
     return Map.of(STATUS, String.valueOf(httpStatus.value()), MESSAGE, message);
   }
-  public static ResponseEntity<Map<String, String>> getGlobalControllerAdviceResponse(HttpStatus httpStatus, String message) {
-    return ResponseEntity.status(httpStatus).body(getGlobalControllerAdviceBodyResponse(httpStatus, message));
+
+  public static ResponseEntity<Map<String, String>> getGlobalControllerAdviceResponse(
+      HttpStatus httpStatus, String message) {
+    return ResponseEntity.status(httpStatus)
+        .body(getGlobalControllerAdviceBodyResponse(httpStatus, message));
   }
 }

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
@@ -24,7 +24,7 @@ public class ReclamationController {
     this.deposerReclamation = deposerReclamation;
   }
 
- /* @PostMapping
+  /* @PostMapping
   @Operation(
       summary = "Déposer une réclamation",
       description = "Permet de déposer une réclamation en envoyant un numéro de dossier",
@@ -46,7 +46,6 @@ public class ReclamationController {
   }
 
   */
-
 
   @PostMapping(consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE})
   public ResponseEntity<String> handleNonBrowserSubmissions(

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
@@ -37,17 +37,19 @@ public class ReclamationController {
     this.deposerReclamation = deposerReclamation;
   }
 
-  //hack: une nouvelle version du webhook doit prochainement être intégrée. Cette version enverra une payload de type application/json. Cette méthode est créée dans l'attente.
+  // hack: une nouvelle version du webhook doit prochainement être intégrée. Cette version enverra
+  // une payload de type application/json. Cette méthode est créée dans l'attente.
   @PostMapping(consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE})
   @Operation(
-          summary = "Récupère une réclamation issue de demat.social",
-          description = "Permet de récupérer une réclamation issue de demat.social grâce un numéro de dossier transmis. Cette API est un webhook destiné à être configuré dans demat.social",
-          responses = {
-                  @ApiResponse(responseCode = "200", description = "Réclamation affectée avec succès"),
-                  @ApiResponse(responseCode = "400", description = "Données invalides dans la requête"),
-                  @ApiResponse(responseCode = "404", description = "Ressources nécessaires introuvables"),
-                  @ApiResponse(responseCode = "500", description = "Erreur interne du serveur")
-          })
+      summary = "Récupère une réclamation issue de demat.social",
+      description =
+          "Permet de récupérer une réclamation issue de demat.social grâce un numéro de dossier transmis. Cette API est un webhook destiné à être configuré dans demat.social",
+      responses = {
+        @ApiResponse(responseCode = "200", description = "Réclamation affectée avec succès"),
+        @ApiResponse(responseCode = "400", description = "Données invalides dans la requête"),
+        @ApiResponse(responseCode = "404", description = "Ressources nécessaires introuvables"),
+        @ApiResponse(responseCode = "500", description = "Erreur interne du serveur")
+      })
   public ResponseEntity<Map<String, String>> handleNonBrowserSubmissions(
       @RequestParam Map<String, String> dsWebhookMap) {
 
@@ -55,27 +57,37 @@ public class ReclamationController {
 
     String message = "";
 
-    if(isValidPayload(dsWebhookMap)) {
-      final DeposerReclamationRequest.Etat etat = DeposerReclamationRequest.Etat.valueOf(dsWebhookMap.get(ETAT_KEY).toUpperCase());
+    if (isValidPayload(dsWebhookMap)) {
+      final DeposerReclamationRequest.Etat etat =
+          DeposerReclamationRequest.Etat.valueOf(dsWebhookMap.get(ETAT_KEY).toUpperCase());
       final int numeroProcedure = Integer.parseInt(dsWebhookMap.get(NUMERO_DEMARCHE_KEY));
       final int numeroDossier = Integer.parseInt(dsWebhookMap.get(NUMERO_DOSSIER_KEY));
-      final LocalDateTime dateDepot = LocalDateTime.parse(dsWebhookMap.get(DATE_DEPOT_KEY), DateTimeFormatter.ofPattern(DATETIME_PATTERN_KEY));
-      final DeposerReclamationRequest deposerReclamationRequest = new DeposerReclamationRequest(numeroProcedure, numeroDossier, etat, dateDepot);
+      final LocalDateTime dateDepot =
+          LocalDateTime.parse(
+              dsWebhookMap.get(DATE_DEPOT_KEY), DateTimeFormatter.ofPattern(DATETIME_PATTERN_KEY));
+      final DeposerReclamationRequest deposerReclamationRequest =
+          new DeposerReclamationRequest(numeroProcedure, numeroDossier, etat, dateDepot);
 
-      if(deposerReclamationRequest.getEtat() == DeposerReclamationRequest.Etat.EN_CONSTRUCTION) {
-        final Reclamation reclamation = deposerReclamation.executer(deposerReclamationRequest.getNumeroDossier());
+      if (deposerReclamationRequest.getEtat() == DeposerReclamationRequest.Etat.EN_CONSTRUCTION) {
+        final Reclamation reclamation =
+            deposerReclamation.executer(deposerReclamationRequest.getNumeroDossier());
         message = ReclamationApiMapper.toReclamationApiResponse(reclamation).toString();
         logger.info("La réclamation : {} à été affectée.", message);
         return GlobalControllerAdvice.getGlobalControllerAdviceResponse(HttpStatus.OK, message);
       } else {
-        message = String.format("Le Dossier %s présenté n'est pas à l'état de Construction.", deposerReclamationRequest.getNumeroDossier());
+        message =
+            String.format(
+                "Le Dossier %s présenté n'est pas à l'état de Construction.",
+                deposerReclamationRequest.getNumeroDossier());
         logger.error(message);
-        return GlobalControllerAdvice.getGlobalControllerAdviceResponse(HttpStatus.BAD_REQUEST, message);
+        return GlobalControllerAdvice.getGlobalControllerAdviceResponse(
+            HttpStatus.BAD_REQUEST, message);
       }
     } else {
       message = "Paramètres envoyés invalides.";
       logger.error(message);
-      return GlobalControllerAdvice.getGlobalControllerAdviceResponse(HttpStatus.BAD_REQUEST, message);
+      return GlobalControllerAdvice.getGlobalControllerAdviceResponse(
+          HttpStatus.BAD_REQUEST, message);
     }
   }
 
@@ -102,9 +114,10 @@ public class ReclamationController {
   }
 
   private static boolean isValidPayload(Map<String, String> params) {
-    return params.size() == 4 && validateInteger(params, NUMERO_DEMARCHE_KEY)
-            && validateInteger(params, NUMERO_DOSSIER_KEY)
-            && validateState(params, ETAT_KEY)
-            && validateDate(params, DATE_DEPOT_KEY);
+    return params.size() == 4
+        && validateInteger(params, NUMERO_DEMARCHE_KEY)
+        && validateInteger(params, NUMERO_DOSSIER_KEY)
+        && validateState(params, ETAT_KEY)
+        && validateDate(params, DATE_DEPOT_KEY);
   }
 }

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
@@ -1,14 +1,16 @@
 package fr.gouv.social.sireclamations.user_side;
 
 import fr.gouv.social.sireclamations.hexagone.DeposerReclamation;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,7 +24,7 @@ public class ReclamationController {
     this.deposerReclamation = deposerReclamation;
   }
 
-  @PostMapping
+ /* @PostMapping
   @Operation(
       summary = "Déposer une réclamation",
       description = "Permet de déposer une réclamation en envoyant un numéro de dossier",
@@ -41,5 +43,17 @@ public class ReclamationController {
         "La réclamation pour le dossier numéro de dossier : {}",
         deposerReclamationRequest.getNumeroDossier() + "à été créée.");
     return ReclamationApiMapper.toReclamationApiResponse(reclamation);
+  }
+
+  */
+
+
+  @PostMapping(consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE})
+  public ResponseEntity<String> handleNonBrowserSubmissions(
+          @RequestParam MultiValueMap<String, String> paramMap) {
+
+    logger.info("MultiValueMap : {}", paramMap.toString());
+
+    return new ResponseEntity<String>(paramMap.toString(), HttpStatus.OK);
   }
 }

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +30,7 @@ public class ReclamationController {
   private static final String ETAT_KEY = "state";
   private static final String DATE_DEPOT_KEY = "updated_at";
   private static final String DATETIME_PATTERN_KEY = "yyyy-MM-dd HH:mm:ss Z";
+  private static final String OUTPUT = "output";
 
   private final DeposerReclamation deposerReclamation;
 
@@ -49,12 +51,10 @@ public class ReclamationController {
         @ApiResponse(responseCode = "404", description = "Ressources nécessaires introuvables"),
         @ApiResponse(responseCode = "500", description = "Erreur interne du serveur")
       })
-  public ResponseEntity<Map<String, String>> handleNonBrowserSubmissions(
+  public ResponseEntity<Map<String, Object>> handleNonBrowserSubmissions(
       @RequestParam Map<String, String> dsWebhookMap) {
 
-    logger.info("Appel Webhook reçu avec les paramètres : {}", dsWebhookMap);
-
-    String message = "";
+    String message;
 
     if (isValidPayload(dsWebhookMap)) {
       final DeposerReclamationRequest.Etat etat =
@@ -67,13 +67,27 @@ public class ReclamationController {
       final DeposerReclamationRequest deposerReclamationRequest =
           new DeposerReclamationRequest(numeroProcedure, numeroDossier, etat, dateDepot);
 
+      logger.info("Appel Webhook reçu avec les paramètres : {}", deposerReclamationRequest);
+
       if (deposerReclamationRequest.getEtat()
           == DeposerReclamationRequest.Etat.EN_CONSTRUCTION) { // todo: devrait être en_instruction
         final Reclamation reclamation =
             deposerReclamation.executer(deposerReclamationRequest.getNumeroDossier());
-        message = ReclamationApiMapper.toReclamationApiResponse(reclamation).toString();
-        logger.info("La réclamation : {} à été affectée.", message);
-        return GlobalControllerAdvice.getGlobalControllerAdviceResponse(HttpStatus.OK, message);
+        message =
+            String.format(
+                "Le Dossier %s présenté à été affecté.",
+                deposerReclamationRequest.getNumeroDossier());
+        logger.info(message);
+        final Map<String, Object> response =
+            new HashMap<>(
+                GlobalControllerAdvice.getGlobalControllerAdviceBodyResponse(
+                    HttpStatus.OK, message));
+        response.put(
+            OUTPUT,
+            ReclamationApiMapper.toReclamationApiResponse(
+                reclamation)); // NB : Output utile pour les démos, et en attendant le branchement
+        // vers le système de traitement.
+        return new ResponseEntity<>(response, HttpStatus.OK);
       } else {
         message =
             String.format(

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
@@ -1,6 +1,5 @@
 package fr.gouv.social.sireclamations.user_side;
 
-import fr.gouv.social.sireclamations.hexagone.DeposerReclamation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,35 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("api/v1/reclamations")
 @Tag(name = "Réclamations", description = "Endpoints pour gérer les réclamations")
 public class ReclamationController {
-  private final DeposerReclamation deposerReclamation;
   private static final Logger logger = LoggerFactory.getLogger(ReclamationController.class);
-
-  public ReclamationController(DeposerReclamation deposerReclamation) {
-    this.deposerReclamation = deposerReclamation;
-  }
-
-  /* @PostMapping
-  @Operation(
-      summary = "Déposer une réclamation",
-      description = "Permet de déposer une réclamation en envoyant un numéro de dossier",
-      responses = {
-        @ApiResponse(responseCode = "200", description = "Réclamation déposée avec succès"),
-        @ApiResponse(responseCode = "400", description = "Données invalides dans la requête"),
-        @ApiResponse(responseCode = "404", description = "Ressources nécessaires introuvables"),
-        @ApiResponse(responseCode = "500", description = "Erreur interne du serveur")
-      })
-  public ReclamationApiResponse deposerReclamation(
-      @RequestBody DeposerReclamationRequest deposerReclamationRequest) {
-    logger.info(
-        "Webhook reçu avec numéro de dossier : {}", deposerReclamationRequest.getNumeroDossier());
-    var reclamation = deposerReclamation.executer(deposerReclamationRequest.getNumeroDossier());
-    logger.info(
-        "La réclamation pour le dossier numéro de dossier : {}",
-        deposerReclamationRequest.getNumeroDossier() + "à été créée.");
-    return ReclamationApiMapper.toReclamationApiResponse(reclamation);
-  }
-
-  */
 
   @PostMapping(consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE})
   public ResponseEntity<String> handleNonBrowserSubmissions(

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
@@ -20,7 +20,7 @@ public class ReclamationController {
 
   @PostMapping(consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE})
   public ResponseEntity<String> handleNonBrowserSubmissions(
-          @RequestParam MultiValueMap<String, String> paramMap) {
+      @RequestParam MultiValueMap<String, String> paramMap) {
 
     logger.info("MultiValueMap : {}", paramMap.toString());
 

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
@@ -68,7 +68,8 @@ public class ReclamationController {
       final DeposerReclamationRequest deposerReclamationRequest =
           new DeposerReclamationRequest(numeroProcedure, numeroDossier, etat, dateDepot);
 
-      if (deposerReclamationRequest.getEtat() == DeposerReclamationRequest.Etat.EN_CONSTRUCTION) {
+      if (deposerReclamationRequest.getEtat()
+          == DeposerReclamationRequest.Etat.EN_CONSTRUCTION) { // todo: devrait être en_instruction
         final Reclamation reclamation =
             deposerReclamation.executer(deposerReclamationRequest.getNumeroDossier());
         message = ReclamationApiMapper.toReclamationApiResponse(reclamation).toString();

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
@@ -5,6 +5,10 @@ import fr.gouv.social.sireclamations.hexagone.domain.Reclamation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -14,11 +18,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.Map;
 
 @RestController
 @RequestMapping("api/v1/reclamations")

--- a/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
+++ b/src/main/java/fr/gouv/social/sireclamations/user_side/ReclamationController.java
@@ -1,29 +1,110 @@
 package fr.gouv.social.sireclamations.user_side;
 
+import fr.gouv.social.sireclamations.hexagone.DeposerReclamation;
+import fr.gouv.social.sireclamations.hexagone.domain.Reclamation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
 
 @RestController
 @RequestMapping("api/v1/reclamations")
 @Tag(name = "Réclamations", description = "Endpoints pour gérer les réclamations")
 public class ReclamationController {
   private static final Logger logger = LoggerFactory.getLogger(ReclamationController.class);
+  private static final String NUMERO_DEMARCHE_KEY = "procedure_id";
+  private static final String NUMERO_DOSSIER_KEY = "dossier_id";
+  private static final String ETAT_KEY = "state";
+  private static final String DATE_DEPOT_KEY = "updated_at";
+  private static final String DATETIME_PATTERN_KEY = "yyyy-MM-dd HH:mm:ss Z";
 
+  private final DeposerReclamation deposerReclamation;
+
+  public ReclamationController(DeposerReclamation deposerReclamation) {
+    this.deposerReclamation = deposerReclamation;
+  }
+
+  //hack: une nouvelle version du webhook doit prochainement être intégrée. Cette version enverra une payload de type application/json. Cette méthode est créée dans l'attente.
   @PostMapping(consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE})
-  public ResponseEntity<String> handleNonBrowserSubmissions(
-      @RequestParam MultiValueMap<String, String> paramMap) {
+  @Operation(
+          summary = "Récupère une réclamation issue de demat.social",
+          description = "Permet de récupérer une réclamation issue de demat.social grâce un numéro de dossier transmis. Cette API est un webhook destiné à être configuré dans demat.social",
+          responses = {
+                  @ApiResponse(responseCode = "200", description = "Réclamation affectée avec succès"),
+                  @ApiResponse(responseCode = "400", description = "Données invalides dans la requête"),
+                  @ApiResponse(responseCode = "404", description = "Ressources nécessaires introuvables"),
+                  @ApiResponse(responseCode = "500", description = "Erreur interne du serveur")
+          })
+  public ResponseEntity<Map<String, String>> handleNonBrowserSubmissions(
+      @RequestParam Map<String, String> dsWebhookMap) {
 
-    logger.info("MultiValueMap : {}", paramMap.toString());
+    logger.info("Appel Webhook reçu avec les paramètres : {}", dsWebhookMap);
 
-    return new ResponseEntity<String>(paramMap.toString(), HttpStatus.OK);
+    String message = "";
+
+    if(isValidPayload(dsWebhookMap)) {
+      final DeposerReclamationRequest.Etat etat = DeposerReclamationRequest.Etat.valueOf(dsWebhookMap.get(ETAT_KEY).toUpperCase());
+      final int numeroProcedure = Integer.parseInt(dsWebhookMap.get(NUMERO_DEMARCHE_KEY));
+      final int numeroDossier = Integer.parseInt(dsWebhookMap.get(NUMERO_DOSSIER_KEY));
+      final LocalDateTime dateDepot = LocalDateTime.parse(dsWebhookMap.get(DATE_DEPOT_KEY), DateTimeFormatter.ofPattern(DATETIME_PATTERN_KEY));
+      final DeposerReclamationRequest deposerReclamationRequest = new DeposerReclamationRequest(numeroProcedure, numeroDossier, etat, dateDepot);
+
+      if(deposerReclamationRequest.getEtat() == DeposerReclamationRequest.Etat.EN_CONSTRUCTION) {
+        final Reclamation reclamation = deposerReclamation.executer(deposerReclamationRequest.getNumeroDossier());
+        message = ReclamationApiMapper.toReclamationApiResponse(reclamation).toString();
+        logger.info("La réclamation : {} à été affectée.", message);
+        return GlobalControllerAdvice.getGlobalControllerAdviceResponse(HttpStatus.OK, message);
+      } else {
+        message = String.format("Le Dossier %s présenté n'est pas à l'état de Construction.", deposerReclamationRequest.getNumeroDossier());
+        logger.error(message);
+        return GlobalControllerAdvice.getGlobalControllerAdviceResponse(HttpStatus.BAD_REQUEST, message);
+      }
+    } else {
+      message = "Paramètres envoyés invalides.";
+      logger.error(message);
+      return GlobalControllerAdvice.getGlobalControllerAdviceResponse(HttpStatus.BAD_REQUEST, message);
+    }
+  }
+
+  private static boolean validateInteger(Map<String, String> params, String key) {
+    try {
+      Integer.parseInt(params.get(key));
+      return true;
+    } catch (NumberFormatException e) {
+      return false;
+    }
+  }
+
+  private static boolean validateState(Map<String, String> params, String key) {
+    return DeposerReclamationRequest.Etat.isValid(params.get(key));
+  }
+
+  private static boolean validateDate(Map<String, String> params, String key) {
+    try {
+      LocalDateTime.parse(params.get(key), DateTimeFormatter.ofPattern(DATETIME_PATTERN_KEY));
+      return true;
+    } catch (DateTimeParseException e) {
+      return false;
+    }
+  }
+
+  private static boolean isValidPayload(Map<String, String> params) {
+    return params.size() == 4 && validateInteger(params, NUMERO_DEMARCHE_KEY)
+            && validateInteger(params, NUMERO_DOSSIER_KEY)
+            && validateState(params, ETAT_KEY)
+            && validateDate(params, DATE_DEPOT_KEY);
   }
 }

--- a/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerIntegrationTest.java
+++ b/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerIntegrationTest.java
@@ -1,10 +1,5 @@
 package fr.gouv.social.sireclamations.user_side;
 
-import static org.hamcrest.Matchers.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -13,6 +8,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -28,8 +30,9 @@ class ReclamationControllerIntegrationTest {
       throws Exception {
     // Given
     int numeroDossier = 186287; // Correspond a un dossier existant avec un Ehpad pour établissement
-    DeposerReclamationRequest request = new DeposerReclamationRequest();
-    request.setNumeroDossier(numeroDossier);
+    DeposerReclamationRequest request =
+        new DeposerReclamationRequest(
+            1, numeroDossier, DeposerReclamationRequest.Etat.EN_CONSTRUCTION, LocalDateTime.now());
 
     // When Then
     mockMvc
@@ -48,7 +51,9 @@ class ReclamationControllerIntegrationTest {
   void lorsqueLonDeposeUneReclamationPourUnDossierInexistant_alorsRetourne404() throws Exception {
     // Given
     int numeroDossier = 1111111111;
-    DeposerReclamationRequest request = new DeposerReclamationRequest();
+    DeposerReclamationRequest request =
+        new DeposerReclamationRequest(
+            1, numeroDossier, DeposerReclamationRequest.Etat.EN_CONSTRUCTION, LocalDateTime.now());
     request.setNumeroDossier(numeroDossier);
 
     // When Then

--- a/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerIntegrationTest.java
+++ b/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerIntegrationTest.java
@@ -1,6 +1,12 @@
 package fr.gouv.social.sireclamations.user_side;
 
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,13 +14,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.time.LocalDateTime;
-
-import static org.hamcrest.Matchers.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerIntegrationTest.java
+++ b/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerIntegrationTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,24 +20,24 @@ class ReclamationControllerIntegrationTest {
 
   @Autowired private MockMvc mockMvc;
 
-  @Autowired private ObjectMapper objectMapper;
-
   @Test
   @Tag("localOnly")
   void lorsqueLonDeposeUneReclamationPourUnDossierExistant_alorsRetourne200EtLaReclamationEnBody()
       throws Exception {
     // Given
-    int numeroDossier = 186287; // Correspond a un dossier existant avec un Ehpad pour établissement
-    DeposerReclamationRequest request =
-        new DeposerReclamationRequest(
-            1, numeroDossier, DeposerReclamationRequest.Etat.EN_CONSTRUCTION, LocalDateTime.now());
-
+    int numeroDemarche = 1;
+    int numeroDossier = 209940; // Correspond a un dossier existant avec un Ehpad pour établissement
+    String etat = "en_construction";
+    String dateDepot = "2025-03-07 19:39:42 +0100";
     // When Then
     mockMvc
         .perform(
             post("/api/v1/reclamations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .param("procedure_id", String.valueOf(numeroDemarche))
+                .param("dossier_id", String.valueOf(numeroDossier))
+                .param("state", etat)
+                .param("updated_at", dateDepot))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.numeroDossier", is(numeroDossier)))
         .andExpect(jsonPath("$.autoritesCompetentes", hasSize(2)))
@@ -49,22 +48,25 @@ class ReclamationControllerIntegrationTest {
   @Test
   void lorsqueLonDeposeUneReclamationPourUnDossierInexistant_alorsRetourne404() throws Exception {
     // Given
+    int numeroDemarche = 1;
     int numeroDossier = 1111111111;
-    DeposerReclamationRequest request =
-        new DeposerReclamationRequest(
-            1, numeroDossier, DeposerReclamationRequest.Etat.EN_CONSTRUCTION, LocalDateTime.now());
-    request.setNumeroDossier(numeroDossier);
+    String etat = "en_construction";
+    String dateDepot = "2025-03-07 19:39:42 +0100";
 
     // When Then
     mockMvc
         .perform(
             post("/api/v1/reclamations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .param("procedure_id", String.valueOf(numeroDemarche))
+                .param("dossier_id", String.valueOf(numeroDossier))
+                .param("state", etat)
+                .param("updated_at", dateDepot))
         .andExpect(status().isNotFound())
         .andExpect(
-            jsonPath("$.error")
+            jsonPath("$.message")
                 .value(
-                    "Erreur API DematSocial pour le dossier numéro 1111111111 : Dossier not found"));
+                    "Erreur API DematSocial pour le dossier numéro 1111111111 : Dossier not found"))
+        .andExpect(jsonPath("$.status").value("404"));
   }
 }

--- a/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerIntegrationTest.java
+++ b/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerIntegrationTest.java
@@ -5,7 +5,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerTest.java
+++ b/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerTest.java
@@ -52,95 +52,95 @@ class ReclamationControllerTest {
   void lorsqueDeposerReclamationRenvoiAutoriteCompetenteNotFoundException_alorsRenvoiUne404()
       throws Exception {
     // Given
-    var numeroDossier = 12345;
-    var dossierRequest =
-        """
-                {
-                    "numeroDossier": "%s"
-                }
-                """
-            .formatted(numeroDossier);
+    int numeroDemarche = 1;
+    int numeroDossier = 12345;
+    String etat = "en_construction";
+    String dateDepot = "2025-03-07 19:39:42 +0100";
+
     given(deposerReclamation.executer(numeroDossier))
         .willThrow(new AutoriteCompetenteNotFoundException("autorite competente not found"));
     // When Then
     mockMvc
         .perform(
             post("/api/v1/reclamations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(dossierRequest))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .param("procedure_id", String.valueOf(numeroDemarche))
+                .param("dossier_id", String.valueOf(numeroDossier))
+                .param("state", etat)
+                .param("updated_at", dateDepot))
         .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$.error").value("autorite competente not found"));
+        .andExpect(jsonPath("$.message").value("autorite competente not found"));
   }
 
   @Test
   void lorsqueDeposerReclamationRenvoiContactNotFoundException_alorsRenvoiUne404()
       throws Exception {
     // Given
-    var numeroDossier = 12345;
-    var dossierRequest =
-        """
-                {
-                    "numeroDossier": "%s"
-                }
-                """
-            .formatted(numeroDossier);
+    int numeroDemarche = 1;
+    int numeroDossier = 12345;
+    String etat = "en_construction";
+    String dateDepot = "2025-03-07 19:39:42 +0100";
+
     given(deposerReclamation.executer(numeroDossier))
         .willThrow(new ContactNotFoundException("contact not found"));
     // When Then
     mockMvc
         .perform(
             post("/api/v1/reclamations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(dossierRequest))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .param("procedure_id", String.valueOf(numeroDemarche))
+                .param("dossier_id", String.valueOf(numeroDossier))
+                .param("state", etat)
+                .param("updated_at", dateDepot))
         .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$.error").value("contact not found"));
+        .andExpect(jsonPath("$.message").value("contact not found"));
   }
 
   @Test
   void lorsqueDeposerReclamationRenvoiDematSocialException_alorsRenvoiUne404() throws Exception {
     // Given
-    var numeroDossier = 12345;
-    var dossierRequest =
-        """
-                {
-                    "numeroDossier": "%s"
-                }
-                """
-            .formatted(numeroDossier);
+    int numeroDemarche = 1;
+    int numeroDossier = 12345;
+    String etat = "en_construction";
+    String dateDepot = "2025-03-07 19:39:42 +0100";
+
     given(deposerReclamation.executer(numeroDossier))
         .willThrow(new DematSocialException("dossier not found"));
     // When Then
     mockMvc
         .perform(
             post("/api/v1/reclamations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(dossierRequest))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .param("procedure_id", String.valueOf(numeroDemarche))
+                .param("dossier_id", String.valueOf(numeroDossier))
+                .param("state", etat)
+                .param("updated_at", dateDepot))
         .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$.error").value("dossier not found"));
+        .andExpect(jsonPath("$.message").value("dossier not found"));
   }
 
   @Test
   void lorsqueDeposerReclamationRenvoiCodePostalAbsentException_alorsRenvoiUne404()
       throws Exception {
     // Given
-    var numeroDossier = 12345;
-    var dossierRequest =
-        """
-                {
-                    "numeroDossier": "%s"
-                }
-                """
-            .formatted(numeroDossier);
+    int numeroDemarche = 1;
+    int numeroDossier = 12345;
+    String etat = "en_construction";
+    String dateDepot = "2025-03-07 19:39:42 +0100";
+
     given(deposerReclamation.executer(numeroDossier))
         .willThrow(new CodePostalAbsentException("code postal absent"));
     // When Then
     mockMvc
         .perform(
             post("/api/v1/reclamations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(dossierRequest))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .param("procedure_id", String.valueOf(numeroDemarche))
+                .param("dossier_id", String.valueOf(numeroDossier))
+                .param("state", etat)
+                .param("updated_at", dateDepot))
         .andExpect(status().isNotFound())
-        .andExpect(jsonPath("$.error").value("code postal absent"));
+        .andExpect(jsonPath("$.message").value("code postal absent"));
   }
 
   @Test
@@ -148,14 +148,11 @@ class ReclamationControllerTest {
       lorsqueDeposerReclamationRenvoiBienLaReclamation_alorsRenvoiUne200AvecLesDonneesDeLaReclamationEnBody()
           throws Exception {
     // Given
-    var numeroDossier = 12345;
-    var dossierRequest =
-        """
-                {
-                    "numeroDossier": "%s"
-                }
-                """
-            .formatted(numeroDossier);
+    int numeroDemarche = 1;
+    int numeroDossier = 12345;
+    String etat = "en_construction";
+    String dateDepot = "2025-03-07 19:39:42 +0100";
+
     var etablissement = new Etablissement("78000000", 500, 78210, "nom etablissement");
     String libelleDuMisEnCause =
         "Un professionnel de santé (médecin, infirmier, aide-soignant, kiné, ostéopathe...)";
@@ -172,12 +169,15 @@ class ReclamationControllerTest {
     mockMvc
         .perform(
             post("/api/v1/reclamations")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(dossierRequest))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .param("procedure_id", String.valueOf(numeroDemarche))
+                .param("dossier_id", String.valueOf(numeroDossier))
+                .param("state", etat)
+                .param("updated_at", dateDepot))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.numeroDossier").value(12345))
-        .andExpect(jsonPath("$.autoritesCompetentes[0]").value("ARS"))
-        .andExpect(jsonPath("$.contacts[0]").value("email@email.fr"))
-        .andExpect(jsonPath("$.lieuDeSurvenue.numeroFiness").value("78000000"));
+        .andExpect(jsonPath("$.output.numeroDossier").value(12345))
+        .andExpect(jsonPath("$.output.autoritesCompetentes[0]").value("ARS"))
+        .andExpect(jsonPath("$.output.contacts[0]").value("email@email.fr"))
+        .andExpect(jsonPath("$.output.lieuDeSurvenue.numeroFiness").value("78000000"));
   }
 }


### PR DESCRIPTION
Prise en charge du webhook dont le content-type est 'application/x-www-form-urlencoded'.

ex: curl --location 'http://localhost:8080/api/v1/reclamations' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'procedure_id=661' \
--data-urlencode 'dossier_id=209940' \
--data-urlencode 'state=en_construction' \
--data-urlencode 'updated_at=2025-03-07 19:39:42 +0100'

+ Harmonisation du response body : status & message
+ HttpLoggingInterceptor setLevel à BASIC pour éviter de logguer des informations sensibles.