### PR TITLE
Simal-80 : Prise en compte des 3 types de lieu mal pris en charge

### DIFF
--- a/src/main/java/fr/gouv/social/sireclamations/hexagone/AffecterReclamation.java
+++ b/src/main/java/fr/gouv/social/sireclamations/hexagone/AffecterReclamation.java
@@ -87,7 +87,22 @@ public class AffecterReclamation {
   private Set<AutoriteCompetente> determinerAutoritesCompetentes(DossierDeReclamation dossier) {
     Set<AutoriteCompetente> autoritesCompetentes = new HashSet<>();
 
-    if (dossier.getLieuDeSurvenu() instanceof Domicile domicile) {
+    Domicile domicile = null;
+    Etablissement etablissement = null;
+    AutreEtablissement autreEtablissement = null;
+    Trajet trajet = null;
+
+    if (dossier.getLieuDeSurvenu() instanceof Domicile d) {
+      domicile = d;
+    } else if (dossier.getLieuDeSurvenu() instanceof Etablissement e) {
+      etablissement = e;
+    } else if (dossier.getLieuDeSurvenu() instanceof AutreEtablissement a) {
+      autreEtablissement = a;
+    } else if (dossier.getLieuDeSurvenu() instanceof Trajet t) {
+      trajet = t;
+    }
+
+    if (domicile != null) {
       // Récupération des données des référentiels existants pour le domicile
       String autoriteCompetentePourLeMisEnCauseADomicile =
           referentielDesAutoritesCompetentesParMisEnCauseADomicile.recupererAutoriteCompetente(
@@ -110,8 +125,9 @@ public class AffecterReclamation {
           .isEmpty()) { // ajoute CD par défaut si aucune autorité compétente n'est trouvée
         autoritesCompetentes.add(AutoriteCompetente.CD);
       }
-    } else if (dossier.getLieuDeSurvenu() instanceof Etablissement etablissement) {
-      // Récupération des données des référentiels existants pour l'établissement
+    } else if (etablissement != null || autreEtablissement != null || trajet != null) {
+
+      // Récupération des données des référentiels existants
       String autoriteCompetentePourLeMisEnCause =
           dossier.getMaltraitance()
               ? referentielDesAutoritesCompetentesParMisEnCauseEnEtablissement
@@ -129,14 +145,17 @@ public class AffecterReclamation {
               .toList();
 
       List<String> autoritesCompetenteParCategorieEtablissement =
-          referentielDesAutoritesCompetentesParCategoriesDEtablissements
-              .recupererAutoritesCompetentesParCodeSousCategorieEtablissement(
-                  etablissement.getCodeSousCategorie());
+          (etablissement != null)
+              ? referentielDesAutoritesCompetentesParCategoriesDEtablissements
+                  .recupererAutoritesCompetentesParCodeSousCategorieEtablissement(
+                      etablissement.getCodeSousCategorie())
+              : List.of();
 
       // Application des règles métier
       Optional.ofNullable(autoriteCompetentePourLeMisEnCause)
           .map(AutoriteCompetente::valueOf)
           .ifPresent(autoritesCompetentes::add);
+
       Optional.ofNullable(autoriteCompetenteParLieuDeSurvenue)
           .map(AutoriteCompetente::valueOf)
           .ifPresent(autoritesCompetentes::add);
@@ -144,7 +163,7 @@ public class AffecterReclamation {
       if (autoriteCompetenteParLieuDeSurvenue == null) {
         if (!autoritesCompetentesParMotifs.isEmpty()) {
           autoritesCompetentes.addAll(convertirCodesAutorites(autoritesCompetentesParMotifs));
-        } else {
+        } else if (!autoritesCompetenteParCategorieEtablissement.isEmpty()) {
           autoritesCompetentes.addAll(
               convertirCodesAutorites(autoritesCompetenteParCategorieEtablissement));
         }

--- a/src/main/java/fr/gouv/social/sireclamations/hexagone/AffecterReclamation.java
+++ b/src/main/java/fr/gouv/social/sireclamations/hexagone/AffecterReclamation.java
@@ -87,90 +87,87 @@ public class AffecterReclamation {
   private Set<AutoriteCompetente> determinerAutoritesCompetentes(DossierDeReclamation dossier) {
     Set<AutoriteCompetente> autoritesCompetentes = new HashSet<>();
 
-    Domicile domicile = null;
-    Etablissement etablissement = null;
-    AutreEtablissement autreEtablissement = null;
-    Trajet trajet = null;
-
-    if (dossier.getLieuDeSurvenu() instanceof Domicile d) {
-      domicile = d;
-    } else if (dossier.getLieuDeSurvenu() instanceof Etablissement e) {
-      etablissement = e;
-    } else if (dossier.getLieuDeSurvenu() instanceof AutreEtablissement a) {
-      autreEtablissement = a;
-    } else if (dossier.getLieuDeSurvenu() instanceof Trajet t) {
-      trajet = t;
-    }
-
-    if (domicile != null) {
-      // Récupération des données des référentiels existants pour le domicile
-      String autoriteCompetentePourLeMisEnCauseADomicile =
-          referentielDesAutoritesCompetentesParMisEnCauseADomicile.recupererAutoriteCompetente(
-              dossier.getLibelleDuMisEnCause());
-
-      String autoriteCompetentePourServiceADomicile =
-          referentielDesAutoritesCompetentesParServicesADomicile.recupererAutoriteCompetente(
-              domicile.getService());
-
-      // Application des règles métiers
-      Optional.ofNullable(autoriteCompetentePourLeMisEnCauseADomicile)
-          .map(AutoriteCompetente::valueOf)
-          .ifPresent(autoritesCompetentes::add);
-      if (autoriteCompetentePourLeMisEnCauseADomicile == null) {
-        Optional.ofNullable(autoriteCompetentePourServiceADomicile)
-            .map(AutoriteCompetente::valueOf)
-            .ifPresent(autoritesCompetentes::add);
-      }
-      if (autoritesCompetentes
-          .isEmpty()) { // ajoute CD par défaut si aucune autorité compétente n'est trouvée
-        autoritesCompetentes.add(AutoriteCompetente.CD);
-      }
-    } else if (etablissement != null || autreEtablissement != null || trajet != null) {
-
-      // Récupération des données des référentiels existants
-      String autoriteCompetentePourLeMisEnCause =
-          dossier.getMaltraitance()
-              ? referentielDesAutoritesCompetentesParMisEnCauseEnEtablissement
-                  .recupererAutoriteCompetente(dossier.getLibelleDuMisEnCause())
-              : null;
-
-      String autoriteCompetenteParLieuDeSurvenue =
-          referentielDesAutoritesCompetentesParLieuDeSurvenue.recupererAutoriteCompetente(
-              dossier.getLieuDeSurvenu().libelleTypeDeLieu());
-
-      List<String> autoritesCompetentesParMotifs =
-          dossier.getMotifs().stream()
-              .map(referentielDesAutoritesCompetentesParMotifs::recupererAutoriteCompetente)
-              .filter(Objects::nonNull)
-              .toList();
-
-      List<String> autoritesCompetenteParCategorieEtablissement =
-          (etablissement != null)
-              ? referentielDesAutoritesCompetentesParCategoriesDEtablissements
-                  .recupererAutoritesCompetentesParCodeSousCategorieEtablissement(
-                      etablissement.getCodeSousCategorie())
-              : List.of();
-
-      // Application des règles métier
-      Optional.ofNullable(autoriteCompetentePourLeMisEnCause)
-          .map(AutoriteCompetente::valueOf)
-          .ifPresent(autoritesCompetentes::add);
-
-      Optional.ofNullable(autoriteCompetenteParLieuDeSurvenue)
-          .map(AutoriteCompetente::valueOf)
-          .ifPresent(autoritesCompetentes::add);
-
-      if (autoriteCompetenteParLieuDeSurvenue == null) {
-        if (!autoritesCompetentesParMotifs.isEmpty()) {
-          autoritesCompetentes.addAll(convertirCodesAutorites(autoritesCompetentesParMotifs));
-        } else if (!autoritesCompetenteParCategorieEtablissement.isEmpty()) {
-          autoritesCompetentes.addAll(
-              convertirCodesAutorites(autoritesCompetenteParCategorieEtablissement));
-        }
-      }
+    if (dossier.getLieuDeSurvenu() instanceof Domicile domicile) {
+      traiterDomicile(dossier, domicile, autoritesCompetentes);
+    } else if (dossier.getLieuDeSurvenu() instanceof Etablissement etablissement) {
+      traiterEtablissement(dossier, etablissement, autoritesCompetentes);
+    } else {
+      traiterLieuCommun(dossier, autoritesCompetentes);
     }
 
     return autoritesCompetentes;
+  }
+
+  private void traiterDomicile(
+      DossierDeReclamation dossier,
+      Domicile domicile,
+      Set<AutoriteCompetente> autoritesCompetentes) {
+    String autoriteCompetentePourLeMisEnCauseADomicile =
+        referentielDesAutoritesCompetentesParMisEnCauseADomicile.recupererAutoriteCompetente(
+            dossier.getLibelleDuMisEnCause());
+    String autoriteCompetentePourServiceADomicile =
+        referentielDesAutoritesCompetentesParServicesADomicile.recupererAutoriteCompetente(
+            domicile.getService());
+
+    Optional.ofNullable(autoriteCompetentePourLeMisEnCauseADomicile)
+        .map(AutoriteCompetente::valueOf)
+        .ifPresent(autoritesCompetentes::add);
+
+    if (autoriteCompetentePourLeMisEnCauseADomicile == null) {
+      Optional.ofNullable(autoriteCompetentePourServiceADomicile)
+          .map(AutoriteCompetente::valueOf)
+          .ifPresent(autoritesCompetentes::add);
+    }
+
+    if (autoritesCompetentes.isEmpty()) {
+      autoritesCompetentes.add(AutoriteCompetente.CD);
+    }
+  }
+
+  private void traiterEtablissement(
+      DossierDeReclamation dossier,
+      Etablissement etablissement,
+      Set<AutoriteCompetente> autoritesCompetentes) {
+    traiterLieuCommun(dossier, autoritesCompetentes);
+    List<String> autoritesCompetenteParCategorieEtablissement =
+        referentielDesAutoritesCompetentesParCategoriesDEtablissements
+            .recupererAutoritesCompetentesParCodeSousCategorieEtablissement(
+                etablissement.getCodeSousCategorie());
+
+    if (!autoritesCompetenteParCategorieEtablissement.isEmpty()) {
+      autoritesCompetentes.addAll(
+          convertirCodesAutorites(autoritesCompetenteParCategorieEtablissement));
+    }
+  }
+
+  private void traiterLieuCommun(
+      DossierDeReclamation dossier, Set<AutoriteCompetente> autoritesCompetentes) {
+    String autoriteCompetentePourLeMisEnCause =
+        dossier.getMaltraitance()
+            ? referentielDesAutoritesCompetentesParMisEnCauseEnEtablissement
+                .recupererAutoriteCompetente(dossier.getLibelleDuMisEnCause())
+            : null;
+    String autoriteCompetenteParLieuDeSurvenue =
+        referentielDesAutoritesCompetentesParLieuDeSurvenue.recupererAutoriteCompetente(
+            dossier.getLieuDeSurvenu().libelleTypeDeLieu());
+
+    List<String> autoritesCompetentesParMotifs =
+        dossier.getMotifs().stream()
+            .map(referentielDesAutoritesCompetentesParMotifs::recupererAutoriteCompetente)
+            .filter(Objects::nonNull)
+            .toList();
+
+    Optional.ofNullable(autoriteCompetentePourLeMisEnCause)
+        .map(AutoriteCompetente::valueOf)
+        .ifPresent(autoritesCompetentes::add);
+
+    Optional.ofNullable(autoriteCompetenteParLieuDeSurvenue)
+        .map(AutoriteCompetente::valueOf)
+        .ifPresent(autoritesCompetentes::add);
+
+    if (autoriteCompetenteParLieuDeSurvenue == null && !autoritesCompetentesParMotifs.isEmpty()) {
+      autoritesCompetentes.addAll(convertirCodesAutorites(autoritesCompetentesParMotifs));
+    }
   }
 
   private Set<AutoriteCompetente> convertirCodesAutorites(List<String> codesAutorites) {

--- a/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/AutreEtablissement.java
+++ b/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/AutreEtablissement.java
@@ -1,33 +1,20 @@
 package fr.gouv.social.sireclamations.hexagone.domain;
 
-public class AutreEtablissement implements LieuDeSurvenue {
+public class AutreEtablissement extends LieuDeSurvenue {
 
-  private final Integer codePostal;
   private final String adresse;
-  private final String typeDeLieu;
 
   public AutreEtablissement(Integer codePostal, String adresse, String typeDeLieu) {
-    this.codePostal = codePostal;
+    super(codePostal, typeDeLieu);
     this.adresse = adresse;
-    this.typeDeLieu = typeDeLieu;
   }
 
-  @Override
-  public Integer getCodePostal() {
-    return this.codePostal;
+  public String getAdresse() {
+    return adresse;
   }
 
   @Override
   public CodeTypeDeLieu getCodeTypeDeLieu() {
     return CodeTypeDeLieu.DOM;
-  }
-
-  @Override
-  public String libelleTypeDeLieu() {
-    return typeDeLieu;
-  }
-
-  public String getAdresse() {
-    return adresse;
   }
 }

--- a/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/AutreEtablissement.java
+++ b/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/AutreEtablissement.java
@@ -1,0 +1,33 @@
+package fr.gouv.social.sireclamations.hexagone.domain;
+
+public class AutreEtablissement implements LieuDeSurvenue {
+
+  private final Integer codePostal;
+  private final String adresse;
+  private final String typeDeLieu;
+
+  public AutreEtablissement(Integer codePostal, String adresse, String typeDeLieu) {
+    this.codePostal = codePostal;
+    this.adresse = adresse;
+    this.typeDeLieu = typeDeLieu;
+  }
+
+  @Override
+  public Integer getCodePostal() {
+    return this.codePostal;
+  }
+
+  @Override
+  public CodeTypeDeLieu getCodeTypeDeLieu() {
+    return CodeTypeDeLieu.DOM;
+  }
+
+  @Override
+  public String libelleTypeDeLieu() {
+    return typeDeLieu;
+  }
+
+  public String getAdresse() {
+    return adresse;
+  }
+}

--- a/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/CodeTypeDeLieu.java
+++ b/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/CodeTypeDeLieu.java
@@ -2,5 +2,8 @@ package fr.gouv.social.sireclamations.hexagone.domain;
 
 public enum CodeTypeDeLieu {
   DOM,
-  ETAB
+  ETAB,
+  AUTRE,
+  CABINET,
+  TRAJET
 }

--- a/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/Domicile.java
+++ b/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/Domicile.java
@@ -1,33 +1,14 @@
 package fr.gouv.social.sireclamations.hexagone.domain;
 
-public class Domicile implements LieuDeSurvenue {
+public class Domicile extends LieuDeSurvenue {
 
-  private final Integer codePostal;
   private final String adresse;
-  private final String typeDeLieu;
-
   private final String service;
 
   public Domicile(Integer codePostal, String adresse, String typeDeLieu, String service) {
-    this.codePostal = codePostal;
+    super(codePostal, typeDeLieu);
     this.adresse = adresse;
-    this.typeDeLieu = typeDeLieu;
     this.service = service;
-  }
-
-  @Override
-  public Integer getCodePostal() {
-    return this.codePostal;
-  }
-
-  @Override
-  public CodeTypeDeLieu getCodeTypeDeLieu() {
-    return CodeTypeDeLieu.DOM;
-  }
-
-  @Override
-  public String libelleTypeDeLieu() {
-    return typeDeLieu;
   }
 
   public String getAdresse() {
@@ -36,5 +17,10 @@ public class Domicile implements LieuDeSurvenue {
 
   public String getService() {
     return service;
+  }
+
+  @Override
+  public CodeTypeDeLieu getCodeTypeDeLieu() {
+    return CodeTypeDeLieu.DOM;
   }
 }

--- a/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/Etablissement.java
+++ b/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/Etablissement.java
@@ -1,20 +1,16 @@
 package fr.gouv.social.sireclamations.hexagone.domain;
 
-public class Etablissement implements LieuDeSurvenue {
-  private String numeroFiness;
-  private int codeSousCategorie;
-  private int codePostal;
-  private String nom;
-
-  private String typeDeLieu;
+public class Etablissement extends LieuDeSurvenue {
+  private final String numeroFiness;
+  private final int codeSousCategorie;
+  private final String nom;
 
   public Etablissement(
       String numeroFiness, int codeSousCategorie, int codePostal, String nom, String typeDeLieu) {
+    super(codePostal, typeDeLieu);
     this.numeroFiness = numeroFiness;
     this.codeSousCategorie = codeSousCategorie;
-    this.codePostal = codePostal;
     this.nom = nom;
-    this.typeDeLieu = typeDeLieu;
   }
 
   public String getNumeroFiness() {
@@ -30,17 +26,7 @@ public class Etablissement implements LieuDeSurvenue {
   }
 
   @Override
-  public Integer getCodePostal() {
-    return this.codePostal;
-  }
-
-  @Override
   public CodeTypeDeLieu getCodeTypeDeLieu() {
     return CodeTypeDeLieu.ETAB;
-  }
-
-  @Override
-  public String libelleTypeDeLieu() {
-    return typeDeLieu;
   }
 }

--- a/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/LieuDeSurvenue.java
+++ b/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/LieuDeSurvenue.java
@@ -1,9 +1,22 @@
 package fr.gouv.social.sireclamations.hexagone.domain;
 
-public interface LieuDeSurvenue {
-  Integer getCodePostal();
+public abstract class LieuDeSurvenue {
 
-  CodeTypeDeLieu getCodeTypeDeLieu();
+  private final Integer codePostal;
+  private final String typeDeLieu;
 
-  String libelleTypeDeLieu();
+  public LieuDeSurvenue(Integer codePostal, String typeDeLieu) {
+    this.codePostal = codePostal;
+    this.typeDeLieu = typeDeLieu;
+  }
+
+  public Integer getCodePostal() {
+    return codePostal;
+  }
+
+  public String libelleTypeDeLieu() {
+    return typeDeLieu;
+  }
+
+  public abstract CodeTypeDeLieu getCodeTypeDeLieu();
 }

--- a/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/LieuDeSurvenue.java
+++ b/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/LieuDeSurvenue.java
@@ -5,7 +5,7 @@ public abstract class LieuDeSurvenue {
   private final Integer codePostal;
   private final String typeDeLieu;
 
-  public LieuDeSurvenue(Integer codePostal, String typeDeLieu) {
+  protected LieuDeSurvenue(Integer codePostal, String typeDeLieu) {
     this.codePostal = codePostal;
     this.typeDeLieu = typeDeLieu;
   }

--- a/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/Trajet.java
+++ b/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/Trajet.java
@@ -1,27 +1,13 @@
 package fr.gouv.social.sireclamations.hexagone.domain;
 
-public class Trajet implements LieuDeSurvenue {
-
-  private final Integer codePostal;
-  private final String typeDeLieu;
+public class Trajet extends LieuDeSurvenue {
 
   public Trajet(Integer codePostal, String typeDeLieu) {
-    this.codePostal = codePostal;
-    this.typeDeLieu = typeDeLieu;
-  }
-
-  @Override
-  public Integer getCodePostal() {
-    return this.codePostal;
+    super(codePostal, typeDeLieu);
   }
 
   @Override
   public CodeTypeDeLieu getCodeTypeDeLieu() {
     return CodeTypeDeLieu.DOM;
-  }
-
-  @Override
-  public String libelleTypeDeLieu() {
-    return typeDeLieu;
   }
 }

--- a/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/Trajet.java
+++ b/src/main/java/fr/gouv/social/sireclamations/hexagone/domain/Trajet.java
@@ -1,0 +1,27 @@
+package fr.gouv.social.sireclamations.hexagone.domain;
+
+public class Trajet implements LieuDeSurvenue {
+
+  private final Integer codePostal;
+  private final String typeDeLieu;
+
+  public Trajet(Integer codePostal, String typeDeLieu) {
+    this.codePostal = codePostal;
+    this.typeDeLieu = typeDeLieu;
+  }
+
+  @Override
+  public Integer getCodePostal() {
+    return this.codePostal;
+  }
+
+  @Override
+  public CodeTypeDeLieu getCodeTypeDeLieu() {
+    return CodeTypeDeLieu.DOM;
+  }
+
+  @Override
+  public String libelleTypeDeLieu() {
+    return typeDeLieu;
+  }
+}

--- a/src/main/java/fr/gouv/social/sireclamations/server_side/DematSocialAdapter.java
+++ b/src/main/java/fr/gouv/social/sireclamations/server_side/DematSocialAdapter.java
@@ -242,66 +242,84 @@ public class DematSocialAdapter implements DematSocial {
   }
 
   private LieuDeSurvenue recupererDomicileOuAutreLieu(
-      JsonNode champCompletDuDomicile,
+      JsonNode champCompletDeLAdresse,
       String libelleTypeDeLieu,
       String libelleService,
       String libelleCodePostal,
       CodeTypeDeLieu codeTypeDeLieu) {
 
-    String adresse = null;
-    String codePostal = null;
+    String adresse =
+        extraireAdresseAPartirDuChampDeRechercheDAdresseComplete(champCompletDeLAdresse);
+    String codePostal = extraireCodePostal(libelleCodePostal, champCompletDeLAdresse);
 
+    Integer codePostalInt = convertirCodePostalEnEntier(codePostal);
+
+    return creerLieuDeSurvenue(
+        adresse, codePostalInt, libelleTypeDeLieu, libelleService, codeTypeDeLieu);
+  }
+
+  private String extraireAdresseAPartirDuChampDeRechercheDAdresseComplete(
+      JsonNode champCompletDuDomicile) {
+    if (champCompletDuDomicile == null) {
+      return null;
+    }
+
+    JsonNode addressNode = champCompletDuDomicile.path(ADRESSE);
+    if (addressNode == null || addressNode.isMissingNode() || addressNode.isNull()) {
+      String stringValue =
+          champCompletDuDomicile.has(STRING_VALUE)
+              ? champCompletDuDomicile.path(STRING_VALUE).asText(null)
+              : null;
+      return (stringValue != null && !stringValue.isEmpty()) ? stringValue : null;
+    }
+
+    String adresse = addressNode.path(ADRESSE_RUE).asText(null);
+    if (adresse == null || adresse.isEmpty()) {
+      String streetNumber = addressNode.path(NUMERO_RUE).asText(null);
+      String streetName = addressNode.path(NOM_RUE).asText(null);
+      String cityName = addressNode.path(VILLE).asText(null);
+      String postalCode = addressNode.path(CODE_POSTAL).asText(null);
+
+      if (streetNumber != null && streetName != null && cityName != null && postalCode != null) {
+        adresse = String.format("%s %s %s %s", streetNumber, streetName, postalCode, cityName);
+      } else {
+        return null; // Retourne null si aucune adresse valide n'a été trouvée
+      }
+    }
+    return adresse;
+  }
+
+  private String extraireCodePostal(String libelleCodePostal, JsonNode champCompletDuDomicile) {
     if (libelleCodePostal != null) {
-      codePostal = libelleCodePostal;
+      return libelleCodePostal;
     }
 
-    // Récupération de l'objet "address" si présent
-    JsonNode addressNode =
-        (champCompletDuDomicile != null) ? champCompletDuDomicile.path(ADRESSE) : null;
+    JsonNode addressNode = champCompletDuDomicile.path(ADRESSE);
     if (addressNode != null && !addressNode.isMissingNode() && !addressNode.isNull()) {
-
-      adresse = addressNode.path(ADRESSE_RUE).asText(null);
-      //      codePostal = addressNode.path(CODE_POSTAL).asText(null);
-
-      // Si l'adresse est composée de plusieurs parties, on essaie de les reconstruire
-      if (adresse == null || adresse.isEmpty()) {
-        String streetNumber = addressNode.path(NUMERO_RUE).asText(null);
-        String streetName = addressNode.path(NOM_RUE).asText(null);
-        String cityName = addressNode.path(VILLE).asText(null);
-        String postalCode = addressNode.path(CODE_POSTAL).asText(null);
-
-        if (streetNumber != null && streetName != null && cityName != null && postalCode != null) {
-          adresse = String.format("%s %s %s %s", streetNumber, streetName, postalCode, cityName);
-          codePostal = postalCode;
-        }
-      }
+      return addressNode.path(CODE_POSTAL).asText(null);
     }
+    return null;
+  }
 
-    // Utiliser "stringValue" si l'adresse est absente ou vide
-    if (adresse == null
-        && champCompletDuDomicile != null
-        && champCompletDuDomicile.has(STRING_VALUE)) {
-      String stringValue = champCompletDuDomicile.path(STRING_VALUE).asText(null);
-      if (stringValue != null && !stringValue.isEmpty()) {
-        adresse = stringValue;
-      }
-    }
-    // Conversion du code postal en entier si possible
-    Integer codePostalInt = null;
+  private Integer convertirCodePostalEnEntier(String codePostal) {
     try {
-      if (codePostal != null) {
-        codePostalInt = Integer.parseInt(codePostal);
-      }
+      return (codePostal != null) ? Integer.parseInt(codePostal) : null;
     } catch (NumberFormatException e) {
-      // Si le code postal est mal formé, on le laisse null
+      return null;
     }
+  }
 
-    // Création de l'objet du lieu de survenue
-    if (CodeTypeDeLieu.DOM.equals(codeTypeDeLieu))
-      return new Domicile(codePostalInt, adresse, libelleTypeDeLieu, libelleService);
-    if (CodeTypeDeLieu.TRAJET.equals(codeTypeDeLieu))
-      return new Trajet(codePostalInt, libelleTypeDeLieu);
-    return new AutreEtablissement(codePostalInt, adresse, libelleTypeDeLieu);
+  private LieuDeSurvenue creerLieuDeSurvenue(
+      String adresse,
+      Integer codePostalInt,
+      String libelleTypeDeLieu,
+      String libelleService,
+      CodeTypeDeLieu codeTypeDeLieu) {
+    return switch (codeTypeDeLieu) {
+      case DOM -> new Domicile(codePostalInt, adresse, libelleTypeDeLieu, libelleService);
+      case TRAJET -> new Trajet(codePostalInt, libelleTypeDeLieu);
+      default -> new AutreEtablissement(codePostalInt, adresse, libelleTypeDeLieu);
+    };
   }
 
   private Etablissement recupererEtablissement(

--- a/src/main/java/fr/gouv/social/sireclamations/server_side/DematSocialAdapter.java
+++ b/src/main/java/fr/gouv/social/sireclamations/server_side/DematSocialAdapter.java
@@ -227,28 +227,26 @@ public class DematSocialAdapter implements DematSocial {
       return recupererEtablissement(nomEtablissementVilleCodePostalEtFiness, libelleTypeDeLieu);
     }
 
-    if (CodeTypeDeLieu.DOM.equals(codeTypeDeLieu)) {
-      String idChampLieuDomicile =
-          champsPourArbre.get(
-              ChampsArbreDeDecision
-                  .LIEU_DOM); // Adresse complète avec auto completion adresse cp et ville
-      String idChampServiceADomicile = champsPourArbre.get(ChampsArbreDeDecision.SERVICE);
-      JsonNode domicileChamp = mapDesChampsDuDossier.get(idChampLieuDomicile);
-      String libelleService =
-          Optional.ofNullable(mapDesChampsDuDossier.get(idChampServiceADomicile))
-              .map(node -> node.path(STRING_VALUE).asText())
-              .orElse(null);
-      return recupererDomicile(domicileChamp, libelleTypeDeLieu, libelleService, libelleCodePostal);
-    }
-
-    return null;
+    String idChampLieuDomicile =
+        champsPourArbre.get(
+            ChampsArbreDeDecision
+                .LIEU_DOM); // Adresse complète avec auto completion adresse cp et ville
+    String idChampServiceADomicile = champsPourArbre.get(ChampsArbreDeDecision.SERVICE);
+    JsonNode domicileChamp = mapDesChampsDuDossier.get(idChampLieuDomicile);
+    String libelleService =
+        Optional.ofNullable(mapDesChampsDuDossier.get(idChampServiceADomicile))
+            .map(node -> node.path(STRING_VALUE).asText())
+            .orElse(null);
+    return recupererDomicileOuAutreLieu(
+        domicileChamp, libelleTypeDeLieu, libelleService, libelleCodePostal, codeTypeDeLieu);
   }
 
-  private LieuDeSurvenue recupererDomicile(
+  private LieuDeSurvenue recupererDomicileOuAutreLieu(
       JsonNode champCompletDuDomicile,
       String libelleTypeDeLieu,
       String libelleService,
-      String libelleCodePostal) {
+      String libelleCodePostal,
+      CodeTypeDeLieu codeTypeDeLieu) {
 
     String adresse = null;
     String codePostal = null;
@@ -258,8 +256,10 @@ public class DematSocialAdapter implements DematSocial {
     }
 
     // Récupération de l'objet "address" si présent
-    JsonNode addressNode = champCompletDuDomicile.path(ADRESSE);
-    if (!addressNode.isMissingNode() && !addressNode.isNull()) {
+    JsonNode addressNode =
+        (champCompletDuDomicile != null) ? champCompletDuDomicile.path(ADRESSE) : null;
+    if (addressNode != null && !addressNode.isMissingNode() && !addressNode.isNull()) {
+
       adresse = addressNode.path(ADRESSE_RUE).asText(null);
       //      codePostal = addressNode.path(CODE_POSTAL).asText(null);
 
@@ -278,7 +278,9 @@ public class DematSocialAdapter implements DematSocial {
     }
 
     // Utiliser "stringValue" si l'adresse est absente ou vide
-    if (adresse == null && champCompletDuDomicile.has(STRING_VALUE)) {
+    if (adresse == null
+        && champCompletDuDomicile != null
+        && champCompletDuDomicile.has(STRING_VALUE)) {
       String stringValue = champCompletDuDomicile.path(STRING_VALUE).asText(null);
       if (stringValue != null && !stringValue.isEmpty()) {
         adresse = stringValue;
@@ -294,8 +296,12 @@ public class DematSocialAdapter implements DematSocial {
       // Si le code postal est mal formé, on le laisse null
     }
 
-    // Création de l'objet Domicile
-    return new Domicile(codePostalInt, adresse, libelleTypeDeLieu, libelleService);
+    // Création de l'objet du lieu de survenue
+    if (CodeTypeDeLieu.DOM.equals(codeTypeDeLieu))
+      return new Domicile(codePostalInt, adresse, libelleTypeDeLieu, libelleService);
+    if (CodeTypeDeLieu.TRAJET.equals(codeTypeDeLieu))
+      return new Trajet(codePostalInt, libelleTypeDeLieu);
+    return new AutreEtablissement(codePostalInt, adresse, libelleTypeDeLieu);
   }
 
   private Etablissement recupererEtablissement(

--- a/src/main/resources/data/mappingFormulaireV2-typeLieux.csv
+++ b/src/main/resources/data/mappingFormulaireV2-typeLieux.csv
@@ -2,7 +2,7 @@
 Au domicile (domicile de la victime, domicile d'un membre de la famille, domicile d'un aidant...);Domicile;DOM
 Dans un établissement de santé (hôpital, clinique, laboratoire, pharmacie ...);Etablissement;ETAB
 Dans un établissement d'hébergement (EHPAD, foyer d'accueil et d'hébergement ...);Etablissement;ETAB
-Dans un établissement ou service social (Centre de jour, service d'aide, service Mandataire Judiciaire à la Protection des Majeurs..;Etablissement;ETAB
-Dans un cabinet médical (dentiste, orthopédique, pédiatrie, médecin généraliste...);Cabinet médical;ETAB
-Durant le trajet (transport sanitaire, SAMU, Pompier);Trajet;ETAB
-Autre (institut d'esthétique, salon de tatouage, prison);Autre;ETAB
+Dans un établissement ou service social (Centre de jour, service d'aide, service Mandataire Judiciaire à la Protection des Majeurs..);Etablissement;ETAB
+Dans un cabinet médical (dentiste, orthopédique, pédiatrie, médecin généraliste...);Cabinet médical;CABINET
+Durant le trajet (transport sanitaire, SAMU, Pompier);Trajet;TRAJET
+Autre (institut d'esthétique, salon de tatouage, prison);Autre;AUTRE

--- a/src/test/java/fr/gouv/social/sireclamations/server_side/DematSocialAdapterTest.java
+++ b/src/test/java/fr/gouv/social/sireclamations/server_side/DematSocialAdapterTest.java
@@ -4,11 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import fr.gouv.social.sireclamations.hexagone.domain.AutreEtablissement;
 import fr.gouv.social.sireclamations.hexagone.domain.ChampsArbreDeDecision;
 import fr.gouv.social.sireclamations.hexagone.domain.CodeTypeDeLieu;
 import fr.gouv.social.sireclamations.hexagone.domain.Domicile;
 import fr.gouv.social.sireclamations.hexagone.domain.DossierDeReclamation;
 import fr.gouv.social.sireclamations.hexagone.domain.Etablissement;
+import fr.gouv.social.sireclamations.hexagone.domain.Trajet;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -387,6 +389,230 @@ class DematSocialAdapterTest {
             178291,
             domicile,
             "Service de Soins Infirmier à Domicile (SSIAD)",
+            true,
+            List.of("Problème comportemental, relationnel ou de communication avec une personne"));
+    assertNotNull(dossierObtenu);
+    assertThat(dossierObtenu).usingRecursiveComparison().isEqualTo(dossierAttendu);
+  }
+
+  @Test
+  void
+      lorsquunDossierExisteEtConcerneUneReclamationDansUnAutreEtablissementDontLadresseEstSaisieEtDontLeMisEnCauseEstUnProfessionnelDeSante_alorsRecupereTousLesChampsNecessaireALaffectation()
+          throws IOException {
+    // Given
+    mockAppelDematSocialApi(
+        """
+            {
+                "data": {
+                    "dossier": {
+                        "number": 178291,
+                        "champs": [
+                            {
+                                "id": "Q2hhbXAtMjcxNTU=",
+                                "__typename": "TextChamp",
+                                "label": "Des actes de maltraitance ont-ils eu lieu ?",
+                                "stringValue": "Oui"
+                            },
+                            {
+                                "id": "Q2hhbXAtMTk1MjY=",
+                                "__typename": "MultipleDropDownListChamp",
+                                "label": "Le ou les types de fait(s)",
+                                "stringValue": "Problème comportemental, relationnel ou de communication avec une personne",
+                                "updatedAt": "2025-03-06T10:25:25+01:00",
+                                "values": [
+                                    "Problème comportemental, relationnel ou de communication avec une personne"
+                                ]
+                            },
+                            {
+                                "id": "Q2hhbXAtMTk1MDU=",
+                                "__typename": "TextChamp",
+                                "label": "Lieu principal de survenue",
+                                "stringValue": "Autre (institut d'esthétique, salon de tatouage, prison)",
+                                "updatedAt": "2025-03-06T10:25:37+01:00"
+                            },
+                            {
+                                "id": "Q2hhbXAtMjcxNjE=",
+                                "__typename": "AddressChamp",
+                                "label": "Adresse concernée",
+                                "stringValue": "81 Avenue Pierre Curie 78210 Saint-Cyr-l'École",
+                                "updatedAt": "2025-03-06T10:25:57+01:00",
+                                "address": {
+                                    "label": "81 Avenue Pierre Curie 78210 Saint-Cyr-l'École",
+                                    "type": "housenumber",
+                                    "streetAddress": "81 Avenue Pierre Curie",
+                                    "streetNumber": "81",
+                                    "streetName": "Avenue Pierre Curie",
+                                    "postalCode": "78210",
+                                    "cityName": "Saint-Cyr-l'École",
+                                    "cityCode": "78545",
+                                    "departmentName": "Yvelines",
+                                    "departmentCode": "78",
+                                    "regionName": "Île-de-France",
+                                    "regionCode": "11"
+                                },
+                                "commune": {
+                                    "name": "Saint-Cyr-l’École",
+                                    "code": "78545",
+                                    "postalCode": "78210"
+                                },
+                                "departement": {
+                                    "name": "Yvelines",
+                                    "code": "78"
+                                }
+                            },
+                            {
+                                "id": "Q2hhbXAtMjgzNjc=",
+                                "__typename": "CommuneChamp",
+                                "label": "Code postal",
+                                "stringValue": "Hardricourt (78250)",
+                                "updatedAt": "2025-03-11T14:49:28+01:00",
+                                "commune": {
+                                    "name": "Hardricourt",
+                                    "code": "78299",
+                                    "postalCode": "78250"
+                                },
+                                "departement": {
+                                    "name": "Yvelines",
+                                    "code": "78"
+                                }
+                            },
+                            {
+                                "id": "Q2hhbXAtMjgzNjg=",
+                                "__typename": "TextChamp",
+                                "label": "Personne responsable des faits",
+                                "stringValue": "Professionnel",
+                                "updatedAt": "2025-03-06T10:25:59+01:00"
+                            },
+                            {
+                                "id": "Q2hhbXAtMTk1MTU=",
+                                "__typename": "TextChamp",
+                                "label": "Avec qui les faits ont-ils eu lieu ?",
+                                "stringValue": "Un professionnel de santé (médecin, infirmier, aide-soignant, kiné, ostéopathe...)",
+                                "updatedAt": "2025-03-06T14:29:52+01:00"
+                            }
+                        ]
+                    }
+                }
+            }
+            """);
+
+    var libelleTypeLieu = "Autre (institut d'esthétique, salon de tatouage, prison)";
+    when(referentielDuTypeDeLieux.recupererCodeTypeDeLieuxAPartirDuLibelle(libelleTypeLieu))
+        .thenReturn(CodeTypeDeLieu.AUTRE);
+    // When
+    var dossierObtenu = dematSocialAdapter.recupererDossier(178291);
+
+    // Then
+    var autreLieu = new AutreEtablissement(78250, "81 Avenue Pierre Curie", libelleTypeLieu);
+    var dossierAttendu =
+        new DossierDeReclamation(
+            178291,
+            autreLieu,
+            "Un professionnel de santé (médecin, infirmier, aide-soignant, kiné, ostéopathe...)",
+            true,
+            List.of("Problème comportemental, relationnel ou de communication avec une personne"));
+    assertNotNull(dossierObtenu);
+    assertThat(dossierObtenu).usingRecursiveComparison().isEqualTo(dossierAttendu);
+  }
+
+  @Test
+  void
+      lorsquunDossierExisteEtConcerneUneReclamationLorsDunTrajetEtDontLeMisEnCauseEstUnProfessionnelDeSante_alorsRecupereTousLesChampsNecessaireALaffectation()
+          throws IOException {
+    // Given
+    mockAppelDematSocialApi(
+        """
+            {
+                "data": {
+                    "dossier": {
+                        "number": 178291,
+                        "champs": [
+                            {
+                                "id": "Q2hhbXAtMjcxNTU=",
+                                "__typename": "TextChamp",
+                                "label": "Des actes de maltraitance ont-ils eu lieu ?",
+                                "stringValue": "Oui"
+                            },
+                            {
+                                "id": "Q2hhbXAtMTk1MjY=",
+                                "__typename": "MultipleDropDownListChamp",
+                                "label": "Le ou les types de fait(s)",
+                                "stringValue": "Problème comportemental, relationnel ou de communication avec une personne",
+                                "updatedAt": "2025-03-06T10:25:25+01:00",
+                                "values": [
+                                    "Problème comportemental, relationnel ou de communication avec une personne"
+                                ]
+                            },
+                            {
+                               "id": "Q2hhbXAtMTk1MDU=",
+                               "__typename": "TextChamp",
+                               "label": "Lieu principal de survenue",
+                               "stringValue": "Durant le trajet (transport sanitaire, SAMU, Pompier)",
+                               "updatedAt": "2025-03-17T10:34:11+01:00"
+                           },
+                           {
+                               "id": "Q2hhbXAtMjcxNjY=",
+                               "__typename": "TextChamp",
+                               "label": "Type de transport concerné",
+                               "stringValue": "Ambulance de secours et de soins d'urgence (ASSU)",
+                               "updatedAt": "2025-03-17T10:34:20+01:00"
+                           },
+                           {
+                               "id": "Q2hhbXAtMjc1ODg=",
+                               "__typename": "TextChamp",
+                               "label": "Société de transport concernée",
+                               "stringValue": "ASSU Dupuis",
+                               "updatedAt": "2025-03-17T10:34:29+01:00"
+                           },
+                           {
+                               "id": "Q2hhbXAtMjgzNjc=",
+                               "__typename": "CommuneChamp",
+                               "label": "Code postal",
+                               "stringValue": "Hardricourt (78250)",
+                               "updatedAt": "2025-03-11T14:49:28+01:00",
+                               "commune": {
+                                   "name": "Hardricourt",
+                                   "code": "78299",
+                                   "postalCode": "78250"
+                               },
+                               "departement": {
+                                   "name": "Yvelines",
+                                   "code": "78"
+                               }
+                             },
+                              {
+                                  "id": "Q2hhbXAtMjgzNjg=",
+                                  "__typename": "TextChamp",
+                                  "label": "Personne responsable des faits",
+                                  "stringValue": "Professionnel",
+                                  "updatedAt": "2025-03-06T10:25:59+01:00"
+                              },
+                              {
+                                  "id": "Q2hhbXAtMTk1MTU=",
+                                  "__typename": "TextChamp",
+                                  "label": "Avec qui les faits ont-ils eu lieu ?",
+                                  "stringValue": "Un professionnel de santé (médecin, infirmier, aide-soignant, kiné, ostéopathe...)",
+                                  "updatedAt": "2025-03-06T14:29:52+01:00"
+                              }
+                        ]
+                    }
+                }
+            }
+            """);
+
+    var libelleTypeLieu = "Durant le trajet (transport sanitaire, SAMU, Pompier)";
+    when(referentielDuTypeDeLieux.recupererCodeTypeDeLieuxAPartirDuLibelle(libelleTypeLieu))
+        .thenReturn(CodeTypeDeLieu.TRAJET);
+    // When
+    var dossierObtenu = dematSocialAdapter.recupererDossier(178291);
+
+    // Then
+    var trajet = new Trajet(78250, libelleTypeLieu);
+    var dossierAttendu =
+        new DossierDeReclamation(
+            178291,
+            trajet,
+            "Un professionnel de santé (médecin, infirmier, aide-soignant, kiné, ostéopathe...)",
             true,
             List.of("Problème comportemental, relationnel ou de communication avec une personne"));
     assertNotNull(dossierObtenu);

--- a/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerIntegrationTest.java
+++ b/src/test/java/fr/gouv/social/sireclamations/user_side/ReclamationControllerIntegrationTest.java
@@ -25,7 +25,7 @@ class ReclamationControllerIntegrationTest {
       throws Exception {
     // Given
     int numeroDemarche = 1;
-    int numeroDossier = 209940; // Correspond a un dossier existant avec un Ehpad pour établissement
+    int numeroDossier = 210310;
     String etat = "en_construction";
     String dateDepot = "2025-03-07 19:39:42 +0100";
     // When Then
@@ -38,9 +38,9 @@ class ReclamationControllerIntegrationTest {
                 .param("state", etat)
                 .param("updated_at", dateDepot))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.numeroDossier", is(numeroDossier)))
-        .andExpect(jsonPath("$.autoritesCompetentes", hasSize(1)))
-        .andExpect(jsonPath("$.autoritesCompetentes", containsInAnyOrder("ARS")));
+        .andExpect(jsonPath("$.output.numeroDossier", is(numeroDossier)))
+        .andExpect(jsonPath("$.output.autoritesCompetentes", hasSize(1)))
+        .andExpect(jsonPath("$.output.autoritesCompetentes", containsInAnyOrder("ARS")));
   }
 
   @Test

--- a/src/test/resources/data/mappingFormulaireV2-typeLieux-test.csv
+++ b/src/test/resources/data/mappingFormulaireV2-typeLieux-test.csv
@@ -2,7 +2,7 @@
 Au domicile (domicile de la victime, domicile d'un membre de la famille, domicile d'un aidant...);Domicile;DOM
 Dans un établissement de santé (hôpital, clinique, laboratoire, pharmacie ...);Etablissement;ETAB
 Dans un établissement d'hébergement (EHPAD, foyer d'accueil et d'hébergement ...);Etablissement;ETAB
-Dans un établissement ou service social (Centre de jour, service d'aide, service Mandataire Judiciaire à la Protection des Majeurs..;Etablissement;ETAB
-Dans un cabinet médical (dentiste, orthopédique, pédiatrie, médecin généraliste...);Cabinet médical;ETAB
-Durant le trajet (transport sanitaire, SAMU, Pompier);Trajet;ETAB
-Autre (institut d'esthétique, salon de tatouage, prison);Autre;ETAB
+Dans un établissement ou service social (Centre de jour, service d'aide, service Mandataire Judiciaire à la Protection des Majeurs..);Etablissement;ETAB
+Dans un cabinet médical (dentiste, orthopédique, pédiatrie, médecin généraliste...);Cabinet médical;CABINET
+Durant le trajet (transport sanitaire, SAMU, Pompier);Trajet;TRAJET
+Autre (institut d'esthétique, salon de tatouage, prison);Autre;AUTRE


### PR DESCRIPTION
Lors de la récupération/mapping du dossier depuis demat social 3 libellés de type de lieu n'était pas pris en charge correctement pour instancier un lieu de survenue :
- Autre (institut d'esthétique, salon de tatouage, prison)
- Durant le trajet (transport sanitaire, SAMU, Pompier)
- Dans un cabinet médical (dentiste, orthopédique, pédiatrie, médecin généraliste...)

**Solution** : Création de nouveaux objets `Cabinet`, `Trajet` et `AutreEtablissement` afin d'instancier correctement les 3 nouveaux type de lieux avec les champs qui leurs sont propre.